### PR TITLE
Expose SpriteBatch's transform matrix parameter

### DIFF
--- a/BenMakesGames.PlayPlayMini.UI/README.md
+++ b/BenMakesGames.PlayPlayMini.UI/README.md
@@ -61,11 +61,11 @@ The theme provider must extend `UIThemeProvider`, and be registered as a service
 public sealed class ThemeProvider: UIThemeProvider
 {
     protected override Theme CurrentTheme { get; set; } = new(
-        WindowColor: Colors.Orange,
+        WindowColor: Color.Orange,
         FontName: "Font",
         ButtonSpriteSheetName: "Button",
-        ButtonLabelColor: Colors.White,
-        ButtonLabelDisabledColor: Colors.Gray,
+        ButtonLabelColor: Color.White,
+        ButtonLabelDisabledColor: Color.Gray,
         CheckboxSpriteSheetName: "Checkbox"
     );
 }

--- a/BenMakesGames.PlayPlayMini/Services/GraphicsManager.cs
+++ b/BenMakesGames.PlayPlayMini/Services/GraphicsManager.cs
@@ -20,6 +20,7 @@ public sealed class GraphicsManager: IServiceLoadContent, IServiceInitialize
 
     public bool FullyLoaded { get; private set; }
 
+    public Matrix? TransformMatrix { get; private set; }
     public int Zoom { get; private set; } = 2;
     public bool FullScreen { get; private set; }
     public int Width { get; private set; } = 1920 / 3;
@@ -157,6 +158,11 @@ public sealed class GraphicsManager: IServiceLoadContent, IServiceInitialize
         SpriteBatch.Dispose();
     }
 
+    public void SetTransformMatrix(Matrix? matrix)
+    {
+        TransformMatrix = matrix;
+    }
+
     public void SetZoom(int zoom)
     {
         Zoom = zoom < 1 ? 1 : zoom;
@@ -208,7 +214,7 @@ public sealed class GraphicsManager: IServiceLoadContent, IServiceInitialize
         DrawCalls = 0;
 
         GraphicsDevice.SetRenderTarget(RenderTarget);
-        SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone);
+        SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, transformMatrix: TransformMatrix);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
As discussed in #4 , making it possible for users to set the `transformMatrix` argument on the `SpriteBatch.Begin` method would make it possible to easily create camera-like behavior. By setting this parameter users can control the offset, rotation, and _zoom_ of the rendered texture.

Here is a short video that shows a simple scene rotating, being translated, and zooming in/out. There are some strange things that happen with the text when zooming and rotating, but I imagine these are to be expected given the "low resolution" at which we're working.

https://github.com/BenMakesGames/PlayPlayMini/assets/3422347/ae1862a4-5aeb-48d0-b71a-4133cc1a4b47

To make this demo I created an extremely simple "camera". Should we include it in this PR as well? Also, do you think there's any documentation that should be added about this feature?

Right now the transform matrix will be preserved even if the current scene/GameState is changed. I think it should be up to the user to "unset" the transformation matrix when needed (should we add an unsetmatrix method?). But I don't know if you agree or you can think of some way to unset it when the scene changes (we could hook into the GameStateManager, but it seems ugly).